### PR TITLE
fix: remove np.float (deprecated)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: stable
+  rev: 23.1.0
   hooks:
     - id: black
       language_version: python3
       args: [--line-length=79]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v4.4.0
   hooks:
     - id: trailing-whitespace  # This hook trims trailing whitespace.
     - id: check-docstring-first  # Checks a common error of defining a docstring after code.
@@ -15,19 +15,15 @@ repos:
     - id: detect-private-key  # Detects the presence of private keys.
     - id: requirements-txt-fixer  # Sorts entries in requirements.txt.
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.6.0
+  rev: v1.10.0
   hooks:
     - id: python-no-eval  # A quick check for the eval() built-in function.
 - repo: https://github.com/myint/docformatter
-  rev: v1.3.1
+  rev: v1.5.1
   hooks:
     - id: docformatter
       args: [--in-place]
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.3
-  hooks:
-    - id: flake8
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v1.8.0
+    rev: 1.13.0
     hooks:
     - id: blacken-docs

--- a/src/loadmydata/load_uea_ucr.py
+++ b/src/loadmydata/load_uea_ucr.py
@@ -81,7 +81,7 @@ def load_uea_ucr_data(name: str) -> Bunch:
     X_train, y_train = load_Xy_from_arff(data_path_train)
     X_test, y_test = load_Xy_from_arff(data_path_test)
     # load description
-    with (open(data_path_description, encoding="ISO-8859-1")) as f:
+    with open(data_path_description, encoding="ISO-8859-1") as f:
         description = f.read()
 
     return Bunch(

--- a/src/loadmydata/padding.py
+++ b/src/loadmydata/padding.py
@@ -23,7 +23,7 @@ def pad_at_the_end(signal: np.ndarray, pad_width: int) -> MaskedArray:
     )
 
 
-def get_signal_shape(signal_padded: MaskedArray) -> (int, int):
+def get_signal_shape(signal_padded: MaskedArray) -> tuple[int, int]:
     err_msg = "Wrong dimensions: {signal_padded.shape}. Expected: (n_samples, n_dims)."
     assert signal_padded.ndim == 2, err_msg
 

--- a/src/loadmydata/padding.py
+++ b/src/loadmydata/padding.py
@@ -4,7 +4,6 @@ from numpy.ma.core import MaskedArray
 
 
 def pad_at_the_end(signal: np.ndarray, pad_width: int) -> MaskedArray:
-
     assert pad_width >= 0, f"pad_width (={pad_width}) must be positive."
 
     if signal.ndim == 1:
@@ -15,7 +14,7 @@ def pad_at_the_end(signal: np.ndarray, pad_width: int) -> MaskedArray:
 
     return ma.masked_array(
         data=np.pad(
-            signal.reshape(n_samples, n_dims).astype(np.float),
+            signal.reshape(n_samples, n_dims).astype(float),
             pad_width=((0, pad_width), (0, 0)),
             mode="constant",
             constant_values=(np.nan,),


### PR DESCRIPTION
Using `numpy.float` resulted in a `AttributeError`.

```
AttributeError: module 'numpy' has no attribute 'float'. `np.float` was a deprecated alias for the builtin `float`.
```